### PR TITLE
add-IncrementalSearch

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .
+

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -32,7 +32,7 @@ $(function() {
     search_list.append(html);
   }
 
-  /*keyupイベントとAjax*/
+  /*keyupイベントとAjax*/　
   $("#user-search-field").on("keyup", function() {
     var users_id = [];
     chat_user.find('.chat-group-user').each( function( index, element ){

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,85 @@
+$(function() {
+  var search_list = $("#user-search-result");
+  const chat_user = $ ('#chat-group-users');
+  /*STEP1:チャットメンバー候補を表示するためのHTML作成*/
+  function appendUser(user) {
+    var html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${ user.name }</p>
+        <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name="${ user.name }">追加</a>
+      </div>`;
+    search_list.append(html);
+  }
+
+  /* STEP2:チャットメンバーに追加HTML作成 */
+  function addChatUser(add_user) {
+    var html = `
+      <div class='chat-group-user clearfix js-chat-member' id='${ add_user.userId }'>
+        <input name='group[user_ids][]' type='hidden' value='${ add_user.userId }'>
+        <p class='chat-group-user__name'>${ add_user.userName }</p>
+        <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn' data-user-id="${add_user.userId}" data-user-name="${add_user.userName}">削除</a>
+      </div>`;
+    $("#chat-group-users").append(html);
+  }
+
+  /* STEP3:チャットメンバーから削除 HTML作成 */
+  function removeUser(user) {
+    var html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${ user.userName }</p>
+        <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.userId}" data-user-name="${user.userName}">追加</a>
+      </div>`;
+    search_list.append(html);
+  }
+
+  /*keyupイベントとAjax*/
+  $("#user-search-field").on("keyup", function() {
+    var users_id = [];
+    chat_user.find('.chat-group-user').each( function( index, element ){
+    users_id.push(element.id);
+    });
+    var input = $("#user-search-field").val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input, users_id: users_id },
+      dataType: 'json'
+    })
+
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0){
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      }
+      else {
+        $("#user-search-result").append(`<div class="chat-group-user clearfix">そのユーザーはいません</div>`);
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    })
+    return false;
+  });
+  //追加ボタンを押した時の動作
+  $("#user-search-result").on("click", ".chat-group-user__btn--add", function(){
+    event.stopPropagation();
+    var add_user = $(this).data();
+    var count = $(".chat-group-user__btn--remove").data();
+    if (add_user.userId !== count.userId){
+      addChatUser(add_user);
+      $(this).parent().remove();
+    }else{
+      alert(add_user.userName + " は登録済みのユーザーです");
+    }
+  });
+  //削除ボタンを押した時の動作
+  $("#chat-group-users").on("click", ".js-remove-btn", function(){
+    event.stopPropagation();
+    var remove_user = $(this).data();
+    removeUser(remove_user);
+    $(this).parent().remove();
+  });
+  return false;
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,10 @@
 class UsersController < ApplicationController
   def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where.not(id: params[:users_id]).where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where.not(id: current_user.id).where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where.not(id: params[:users_id]).where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,12 +12,26 @@
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      #chat-group-users
+        - @group.users.each do |user|
+          .chat-group-user.clearfix.js-chat-member{id: "#{user.id}"}
+            = hidden_field_tag 'group[user_ids][]', user.id
+            %p.chat-group-user__name #{user.name}
+            - if current_user.id == user.id
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{"data-user-id": "#{user.id}", "data-user-name": "#{user.name}"}
+            - else
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{"data-user-id": "#{user.id}", "data-user-name": "#{user.name}"}削除
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
           Member:
           %li.member
             - @group.users.each do |user|
-              %li #{user.name} /
+              %li= user.name + '/'
       .right-header
         .right-header__button
           = link_to "Edit", edit_group_path(@group)

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,8 @@
         %ul.left-header__members
           Member:
           %li.member
-            = @group.name
+            - @group.users.each do |user|
+              %li #{user.name} /
       .right-header
         .right-header__button
           = link_to "Edit", edit_group_path(@group)

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    resources :users, only: [:index]
   end
 end


### PR DESCRIPTION
# What
インクリメンタルサーチの実装
1. ヘッダーにメンバー名の表示
1. API側の準備
1. テキストフィールドの作成
1. 入力される度にイベント発火→イベント時に非同期通信→HTML作成→ビュー上に追加
1. エラー時の処理
1. 追加ボタンが押された時にイベント発火
1. ユーザーの名前を追加し、検索結果から削除
1. 削除を押すとチャットメンバーから削除される
1. 編集メンバーでは既存のユーザーが追加済みの状態であることを確認

# Why
UXの向上

# Gyazo
1.  メンバー１人削除
https://gyazo.com/2ef4c27448d79c17e94e61339b97fc53
2. メンバー２人追加
https://gyazo.com/4364eb91a3f703748b4b2d89b6d5e8ff