### PR TITLE
add-Automatic-updating

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    haml (5.1.1)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     haml-rails (1.0.0)
@@ -149,7 +149,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.0.7.2)
       actionpack (= 5.0.7.2)
@@ -210,9 +210,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    turbolinks (5.2.0)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -253,7 +250,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,9 +1,9 @@
-$(document).on('turbolinks:load', function(){
+$(function(){
   // メッセージ表示のHTML生成
   function buildHTML(message) {
     var content = message.content ? `${ message.content }` : "";
     var image_url = (message.image_url) ? `<image class="lower-message_image" src="${ message.image_url }">` : "";
-    var html = `<div class="message" id="${ message.id }">
+    var html = `<div class="message" data-message-id="${ message.id }">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${ message.name }
@@ -15,8 +15,8 @@ $(document).on('turbolinks:load', function(){
                   <div class="lower-message">
                     <p class="lower-message__content">
                       ${message.content}
-                      ${image_url}
                     </p>
+                      ${image_url}
                   </div>
                 </div>`
     return html;
@@ -47,4 +47,34 @@ $(document).on('turbolinks:load', function(){
       $('.form__submit').attr('disabled', false);
     })
   })
+
+//自動更新
+  $(function(){
+    setInterval(autoUpdate, 3000);
+  });
+  function autoUpdate() {
+    if (location.href.match(/\/groups\/\d+\/messages/)) {
+      var last_message_id = $('.message').last().data('message-id');
+      $.ajax({
+        url: 'api/messages',
+        type: 'GET',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+          messages.forEach(function(message) {
+          var html = buildHTML(message);
+            $('.messages').append(html);
+            $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+          });
+        }
+       })
+       .fail(function(){
+        alert("自動メッセージ取得に失敗しました");
+      })
+    } else {
+      clearInterval(autoUpdate);
+    }
+  };
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -32,7 +32,7 @@ $(function() {
     search_list.append(html);
   }
 
-  /*keyupイベントとAjax*/　
+  /*keyupイベントとAjax*/
   $("#user-search-field").on("keyup", function() {
     var users_id = [];
     chat_user.find('.chat-group-user').each( function( index, element ){

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,13 @@
+class Api::MessagesController < ApplicationController
+  before_action :set_group
+
+  def index
+    @messages = @group.messages.where('id > ?', params[:id])
+  end
+
+  private
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,8 +5,8 @@
     %title ChatSpace
     = csrf_meta_tags
     %script src="main.js"
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ 'data-message-id': message.id }
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,4 @@
-json.id @message.id
-json.content @message.content
-json.image_url @message.image_url
+json.(@message, :content, :image_url)
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Rails.application.routes.draw do
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
     resources :users, only: [:index]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
1. _message.html.hamlにカスタムデータ属性を付与
1. メッセージ更新のためのアクション、ルーティングを実装
1. 取得した最新のメッセージをブラウザのメッセージ一覧に追加
1. 3秒ごとにリクエストし、メッセージ分だけスクロールするよう実装
1. メッセージ一覧のページにだけ自動更新が発火するように実装
# why
自動更新はチャットアプリの必要機能であるため

# Gyazo
https://gyazo.com/b85c42a6a7c479bf37000e40ac2337f6